### PR TITLE
Remove deprecated dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          check-latest: true
       - name: "Check"
         run: make check
       - name: "Build"

--- a/.github/workflows/e2e-olm.yml
+++ b/.github/workflows/e2e-olm.yml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          check-latest: true
       - name: "Publish Images"
         id: "publish"
         run: |
@@ -63,6 +64,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          check-latest: true
       - name: 'SetUp KinD'
         uses: container-tools/kind-action@v2
         with:

--- a/.github/workflows/e2e-operator.yml
+++ b/.github/workflows/e2e-operator.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          check-latest: true
       - name: "Publish Image"
         id: "publish"
         run: |
@@ -43,6 +44,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          check-latest: true
       - name: 'SetUp KinD'
         uses: container-tools/kind-action@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+          check-latest: true
       - name: "Login to Container registry"
         uses: docker/login-action@v3
         with:

--- a/cmd/run/run.go
+++ b/cmd/run/run.go
@@ -1,24 +1,23 @@
 package run
 
 import (
-	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/resources"
-	"github.com/pkg/errors"
+	"fmt"
+
+	routev1 "github.com/openshift/api/route/v1"
 	"github.com/spf13/cobra"
 	admregv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	rtcache "sigs.k8s.io/controller-runtime/pkg/cache"
 	rtclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/controller"
-
 	daprApi "github.com/dapr-sandbox/dapr-kubernetes-operator/api/operator/v1alpha1"
 	daprCtl "github.com/dapr-sandbox/dapr-kubernetes-operator/internal/controller/operator"
-	routev1 "github.com/openshift/api/route/v1"
-
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/controller"
+	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/resources"
 )
 
 func init() {
@@ -48,7 +47,7 @@ func NewRunCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			selector, err := daprCtl.ReleaseSelector()
 			if err != nil {
-				return errors.Wrap(err, "unable to compute cache's watch selector")
+				return fmt.Errorf("unable to compute cache's watch selector: %w", err)
 			}
 
 			controllerOpts.WatchSelectors = map[rtclient.Object]rtcache.ByObject{
@@ -70,7 +69,7 @@ func NewRunCmd() *cobra.Command {
 			return controller.Start(controllerOpts, func(manager manager.Manager, opts controller.Options) error {
 				_, err := daprCtl.NewReconciler(cmd.Context(), manager, helmOpts)
 				if err != nil {
-					return errors.Wrap(err, "unable to set-up DaprControlPlane reconciler")
+					return fmt.Errorf("unable to set-up DaprControlPlane reconciler: %w", err)
 				}
 
 				return nil

--- a/go.mod
+++ b/go.mod
@@ -11,12 +11,10 @@ require (
 	github.com/openshift/api v0.0.0-20230816181854-a7ca92db022a
 	github.com/operator-framework/api v0.17.7
 	github.com/operator-framework/operator-lifecycle-manager v0.22.0
-	github.com/pkg/errors v0.9.1
 	github.com/rs/xid v1.5.0
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
 	github.com/wI2L/jsondiff v0.4.0
-	go.uber.org/multierr v1.11.0
 	golang.org/x/time v0.3.0
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.13.0
@@ -110,6 +108,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc4 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
 	github.com/prometheus/client_model v0.4.0 // indirect
@@ -128,6 +127,7 @@ require (
 	go.opentelemetry.io/otel v1.14.0 // indirect
 	go.opentelemetry.io/otel/trace v1.14.0 // indirect
 	go.starlark.net v0.0.0-20230814145427-12f4cb8177e4 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.25.0 // indirect
 	golang.org/x/crypto v0.13.0 // indirect
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect

--- a/internal/controller/operator/dapr_controller_action_conditions.go
+++ b/internal/controller/operator/dapr_controller_action_conditions.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/controller/client"
 	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/helm"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -42,7 +41,7 @@ func (a *ConditionsAction) Configure(_ context.Context, _ *client.Client, b *bui
 func (a *ConditionsAction) Run(ctx context.Context, rc *ReconciliationRequest) error {
 	crs, err := CurrentReleaseSelector(rc)
 	if err != nil {
-		return errors.Wrap(err, "cannot compute current release selector")
+		return fmt.Errorf("cannot compute current release selector: %w", err)
 	}
 
 	deployments, err := rc.Client.AppsV1().Deployments(rc.Resource.Namespace).List(ctx, metav1.ListOptions{
@@ -50,7 +49,7 @@ func (a *ConditionsAction) Run(ctx context.Context, rc *ReconciliationRequest) e
 	})
 
 	if err != nil {
-		return errors.Wrap(err, "cannot list deployments")
+		return fmt.Errorf("cannot list deployments: %w", err)
 	}
 
 	ready := 0

--- a/internal/controller/operator/dapr_controller_support.go
+++ b/internal/controller/operator/dapr_controller_support.go
@@ -2,17 +2,17 @@ package operator
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 
-	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/controller/predicates"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	ctrlCli "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/controller/predicates"
 )
 
 func gcSelector(rc *ReconciliationRequest) (labels.Selector, error) {
@@ -23,7 +23,7 @@ func gcSelector(rc *ReconciliationRequest) (labels.Selector, error) {
 		[]string{rc.Resource.Namespace})
 
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot determine release namespace requirement")
+		return nil, fmt.Errorf("cannot determine release namespace requirement: %w", err)
 	}
 
 	name, err := labels.NewRequirement(
@@ -32,7 +32,7 @@ func gcSelector(rc *ReconciliationRequest) (labels.Selector, error) {
 		[]string{rc.Resource.Name})
 
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot determine release name requirement")
+		return nil, fmt.Errorf("cannot determine release name requirement: %w", err)
 	}
 
 	generation, err := labels.NewRequirement(
@@ -41,7 +41,7 @@ func gcSelector(rc *ReconciliationRequest) (labels.Selector, error) {
 		[]string{strconv.FormatInt(rc.Resource.Generation, 10)})
 
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot determine generation requirement")
+		return nil, fmt.Errorf("cannot determine generation requirement: %w", err)
 	}
 
 	selector := labels.NewSelector().
@@ -115,7 +115,7 @@ func CurrentReleaseSelector(rc *ReconciliationRequest) (labels.Selector, error) 
 		[]string{rc.Resource.Namespace})
 
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot determine release namespace requirement")
+		return nil, fmt.Errorf("cannot determine release namespace requirement: %w", err)
 	}
 
 	name, err := labels.NewRequirement(
@@ -124,7 +124,7 @@ func CurrentReleaseSelector(rc *ReconciliationRequest) (labels.Selector, error) 
 		[]string{rc.Resource.Name})
 
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot determine release name requirement")
+		return nil, fmt.Errorf("cannot determine release name requirement: %w", err)
 	}
 
 	generation, err := labels.NewRequirement(
@@ -133,7 +133,7 @@ func CurrentReleaseSelector(rc *ReconciliationRequest) (labels.Selector, error) 
 		[]string{strconv.FormatInt(rc.Resource.Generation, 10)})
 
 	if err != nil {
-		return nil, errors.Wrap(err, "cannot determine generation requirement")
+		return nil, fmt.Errorf("cannot determine generation requirement: %w", err)
 	}
 
 	selector := labels.NewSelector().

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -1,16 +1,10 @@
 package controller
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/pprof"
 	"time"
-
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-
-	"github.com/pkg/errors"
-
-	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/logger"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -20,9 +14,13 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	"github.com/dapr-sandbox/dapr-kubernetes-operator/pkg/logger"
 )
 
 var (
@@ -56,18 +54,18 @@ func Start(options Options, setup func(manager.Manager, Options) error) error {
 	})
 
 	if err != nil {
-		return errors.Wrap(err, "unable to create manager")
+		return fmt.Errorf("unable to create manager: %w", err)
 	}
 
 	if err := setup(mgr, options); err != nil {
-		return errors.Wrap(err, "unable to set up controllers")
+		return fmt.Errorf("unable to set up controllers: %w", err)
 	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		return errors.Wrap(err, "unable to set up health check")
+		return fmt.Errorf("unable to set up health check: %w", err)
 	}
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		return errors.Wrap(err, "unable to set up readiness check")
+		return fmt.Errorf("unable to set up readiness check: %w", err)
 	}
 
 	if options.PprofAddr != "" {
@@ -96,7 +94,7 @@ func Start(options Options, setup func(manager.Manager, Options) error) error {
 	Log.Info("starting manager")
 
 	if err := mgr.Start(ctx); err != nil {
-		return errors.Wrap(err, "problem running manager")
+		return fmt.Errorf("problem running manager: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
- github.com/pkg/errors is deprecated in favor of the standard library
- go.uber.org/multierr was used once and it's now part of the standard library in Go 1.20