### PR TITLE
Remove support for the deprecated dapr dashboard

### DIFF
--- a/helm-charts/dapr/README.md
+++ b/helm-charts/dapr/README.md
@@ -273,10 +273,6 @@ helm install dapr dapr/dapr --namespace dapr-system --create-namespace --set-str
 ## Example of installing dapr on Minikube
 Configure a values file with these options:
 ```yaml
-dapr_dashboard:
-  runAsNonRoot: false
-  logLevel: DEBUG
-  serviceType: NodePort  # Allows retrieving the dashboard url by running the command "minikube service list"
 dapr_placement:
   runAsNonRoot: false
   logLevel: DEBUG

--- a/internal/controller/operator/instance/dapr_instance_controller_reconcile.go
+++ b/internal/controller/operator/instance/dapr_instance_controller_reconcile.go
@@ -55,7 +55,6 @@ func (r *Reconciler) reconciliationRequest(res *daprApi.DaprInstance) (Reconcili
 				"dapr_operator":         map[string]any{"runAsNonRoot": "true"},
 				"dapr_placement":        map[string]any{"runAsNonRoot": "true"},
 				"dapr_sentry":           map[string]any{"runAsNonRoot": "true"},
-				"dapr_dashboard":        map[string]any{"runAsNonRoot": "true"},
 				"dapr_sidecar_injector": map[string]any{"runAsNonRoot": true},
 			},
 		},


### PR DESCRIPTION
## Summary

The `dapr/dashboard` repository is archived and its Helm chart is being deprecated. This PR removes operator support for the `dapr_dashboard` Helm component so the operator no longer deploys or reconciles it.

**Changes:**
- `internal/controller/operator/instance/dapr_instance_controller_reconcile.go`: removed the `dapr_dashboard` entry from the `chartOverrides` map in `reconciliationRequest()`. The entry set `runAsNonRoot: true` on the dashboard sub-chart; all other component overrides are unchanged.
- `helm-charts/dapr/README.md`: removed the `dapr_dashboard` stanza from the Minikube example values block.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] `go vet ./...` passes with no issues (verified locally)
- [ ] `gofmt -l` on changed `.go` file returns empty (verified locally)
- [ ] No remaining `dapr_dashboard` references in Go source (`grep -rin "dashboard" . --include=*.go` returns empty)